### PR TITLE
[B-1366] Add GH action to trigger mpc-uniqueness-check-deploy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# General code
+* @worldcoin/crypto @worldcoin/orb-backend

--- a/.github/workflows/update-deployment.yaml
+++ b/.github/workflows/update-deployment.yaml
@@ -1,0 +1,23 @@
+name: Update deployment ref number
+
+on: [push]
+
+jobs:
+  update-deployment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GIT_HUB_TOKEN }}
+          repository: worldcoin/mpc-uniqueness-check-deploy
+          event-type: update-ref
+          client-payload: |
+            {
+              "sha": "${{ github.sha }}",
+              "ref": "${{ github.ref }}",
+              "ref_name": "${{ github.ref_name }}",
+              "ref_type": "${{ github.ref_type }}",
+              "repository": "${{ github.repository }}"
+            }


### PR DESCRIPTION
## Motivation
This repo will become opensource in the foreseeable future, so we would like to adopt a CD approach similar to what we have for other opensource projects (like `signup-sequencer`).
This involves emitting an event to a different repository when needed.

## Solution
The solution implemented is a small Github job that triggers on every push. This might change in the future and become pushes to main, but for now I'm keeping it quite open, so to simplify and speed up iterations.