### PR TITLE
fix(db-sync): handle unexpected db sync payload format

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -461,7 +461,18 @@ impl Coordinator {
                 .receipt_handle
                 .context("Missing receipt handle in message")?;
 
-            let items: Vec<DbSyncPayload> = serde_json::from_str(&body)?;
+            let items = if let Ok(items) =
+                serde_json::from_str::<Vec<DbSyncPayload>>(&body)
+            {
+                items
+            } else {
+                tracing::error!(
+                    ?receipt_handle,
+                    "Failed to parse message body"
+                );
+                continue;
+            };
+
             let masks: Vec<_> =
                 items.into_iter().map(|item| (item.id, item.mask)).collect();
 

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -179,7 +179,18 @@ impl Participant {
                 .receipt_handle
                 .context("Missing receipt handle in message")?;
 
-            let items: Vec<DbSyncPayload> = serde_json::from_str(&body)?;
+            let items = if let Ok(items) =
+                serde_json::from_str::<Vec<DbSyncPayload>>(&body)
+            {
+                items
+            } else {
+                tracing::error!(
+                    ?receipt_handle,
+                    "Failed to parse message body"
+                );
+                continue;
+            };
+
             let shares: Vec<_> = items
                 .into_iter()
                 .map(|item| (item.id, item.share))


### PR DESCRIPTION
This PR introduces logic to gracefully handle unexpected format from a db sync payload for both the coordinator and the participant. Instead of propagating an error when failing to parse the message body into `Vec<DbSyncPayload>`, the update now logs an error and continues processing other messages in the queue.


```rust
  let items = if let Ok(items) =
                serde_json::from_str::<Vec<DbSyncPayload>>(&body)
            {
                items
            } else {
                tracing::error!(
                    ?receipt_handle,
                    "Failed to parse message body"
                );
                continue;
            };
 ```