### PR TITLE
feat(B-1468): Pass name of the default branch to the builder

### DIFF
--- a/.github/workflows/update-deployment.yaml
+++ b/.github/workflows/update-deployment.yaml
@@ -19,5 +19,6 @@ jobs:
               "ref": "${{ github.ref }}",
               "ref_name": "${{ github.ref_name }}",
               "ref_type": "${{ github.ref_type }}",
-              "repository": "${{ github.repository }}"
+              "repository": "${{ github.repository }}",
+              "default_branch": "${{ github.event.repository.default_branch }}"
             }


### PR DESCRIPTION
## Motivation

There is a need connected to E2E tests to be able to identify the latest commit that went to production

## Solution

We add a `latest` tag in the builder repo when we build for the default branch. To do this correctly, we need to know what is the default branch for this repo. We could hardcode `main` downstream which would work now, but would break later.