### PR TITLE
Truncate best n matches

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,7 @@ pub struct CoordinatorConfig {
     )]
     pub latest_serial_id_interval: Duration,
     pub hamming_distance_threshold: f64,
+    pub n_closest_distances: usize,
     pub db: DbConfig,
     pub queues: CoordinatorQueuesConfig,
     #[serde(default)]
@@ -176,6 +177,7 @@ mod tests {
                 participant_connection_timeout: Duration::from_secs(1),
                 latest_serial_id_interval: Duration::from_secs(5),
                 hamming_distance_threshold: 0.375,
+                n_closest_distances: 20,
                 db: DbConfig {
                     url: "postgres://localhost:5432/mpc".to_string(),
                     migrate: true,

--- a/tests/e2e_config.toml
+++ b/tests/e2e_config.toml
@@ -8,6 +8,7 @@ queues.distances_queue_url = "http://localhost:4566/000000000000/coordinator-dis
 queues.db_sync_queue_url = "http://localhost:4566/000000000000/coordinator-db-sync"
 participants = '["0.0.0.0:8080", "0.0.0.0:8081"]'
 hamming_distance_threshold = 0.375
+n_closest_distances = 10
 
 [[participant]]
 socket_addr = "0.0.0.0:8080"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We currently attempt to send all the iris matches below a threshold. This recently resulted in a problem where we had 5301 matches. We could not write the MPC Result to SQS since it has a limit of 256KiB bodies. See more details [here](https://www.notion.so/worldcoin/Mini-Postmortem-Signup-stuck-in-progress-a332304e800e4970a890c17d17e73afa?pvs=4). This PR fixes this problem.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
It seems we already thought of a config variable named `n_closest_distances` but never made use of it. In this PR, we sort all the matches in ascending distances and truncate the first `n_closest_distances` matches.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes