### PR TITLE
return n_untruncated_matches as part of UniquenessCheckResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .env
 mock_templates.json
+/.idea

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -108,13 +108,23 @@ impl PartialEq for Distance {
 pub struct DistanceResults {
     /// The lowest serial id known across all nodes
     pub serial_id: u64,
-    /// The distances to the query
+    /// The distances to the query - truncated by n_closest_distances config variable
     pub matches: Vec<Distance>,
+    // The number of matches before truncation
+    pub n_untruncated_matches: u32,
 }
 
 impl DistanceResults {
-    pub fn new(serial_id: u64, matches: Vec<Distance>) -> Self {
-        Self { serial_id, matches }
+    pub fn new(
+        serial_id: u64,
+        matches: Vec<Distance>,
+        n_untruncated_matches: u32,
+    ) -> Self {
+        Self {
+            serial_id,
+            matches,
+            n_untruncated_matches,
+        }
     }
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -346,6 +346,10 @@ async fn run_signup_sequence(
             uniqueness_check_result.matches.len(),
             element.matched_with.len(),
         );
+        assert!(
+            uniqueness_check_result.n_untruncated_matches as usize
+                >= element.matched_with.len()
+        );
 
         // Assert matches against expected values
         if !uniqueness_check_result.matches.is_empty() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We are truncating the best matches for the time being. In order to be able to block supermatchers, in this PR, we return the original number of matches before truncation.

## Solution

Adding a new u32 field on UniquenessCheckResult.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes